### PR TITLE
'transparent_indexes' + green glitch

### DIFF
--- a/examples/displayio_flipclock_ntp_test.py
+++ b/examples/displayio_flipclock_ntp_test.py
@@ -65,7 +65,7 @@ clock = FlipClock(
     SPRITE_WIDTH,
     SPRITE_HEIGHT,
     anim_delay=ANIMATION_DELAY,
-#    transparent_indexes=TRANSPARENT_INDEXES,
+    #    transparent_indexes=TRANSPARENT_INDEXES,
     brighter_level=BRIGHTER_LEVEL,
     darker_level=DARKER_LEVEL,
     medium_level=MEDIUM_LEVEL,

--- a/examples/displayio_flipclock_ntp_test.py
+++ b/examples/displayio_flipclock_ntp_test.py
@@ -47,6 +47,11 @@ bottom_animation_spritesheet, bottom_animation_palette = adafruit_imageload.load
     "grey_bottom_animation_sheet.bmp"
 )
 
+# set the transparent color indexes in respective palettes
+for i in TRANSPARENT_INDEXES:
+    top_animation_palette.make_transparent(i)
+    bottom_animation_palette.make_transparent(i)
+
 SPRITE_WIDTH = static_spritesheet.width // 3
 SPRITE_HEIGHT = (static_spritesheet.height // 4) // 2
 
@@ -60,7 +65,7 @@ clock = FlipClock(
     SPRITE_WIDTH,
     SPRITE_HEIGHT,
     anim_delay=ANIMATION_DELAY,
-    transparent_indexes=TRANSPARENT_INDEXES,
+#    transparent_indexes=TRANSPARENT_INDEXES,
     brighter_level=BRIGHTER_LEVEL,
     darker_level=DARKER_LEVEL,
     medium_level=MEDIUM_LEVEL,


### PR DESCRIPTION
(I made this 6 days ago, I apparently forgot to send the PR... I am very confused but I still believe this is needed)

If I don't comment out that line, I get the following:
```
TypeError: unexpected keyword argument 'transparent_indexes'
```

When removing it, I see the "green" glitch (I see the green that should be transparent) when a digit is "rotating".

Adding this piece of code from another example fix both problem for me.
```
# set the transparent color indexes in respective palettes
for i in TRANSPARENT_INDEXES:
    top_animation_palette.make_transparent(i)
    bottom_animation_palette.make_transparent(i)
```

Not sure exactly what I am doing, but figuring a PR was the easy way to highlight where I have the error.

PS: I also added `    dynamic_fading=True,` but don't ask me why. :-)