### PR TITLE
update palettefader import

### DIFF
--- a/adafruit_displayio_flipclock/flip_digit.py
+++ b/adafruit_displayio_flipclock/flip_digit.py
@@ -125,9 +125,7 @@ class FlipDigit(Widget):
         bottom_palette = None
         top_palette = None
         if dynamic_fading:
-            from cedargrove_palettefader import (
-                PaletteFader,
-            )
+            from cedargrove_palettefader.palettefader import PaletteFader
 
             self.static_fader = PaletteFader(static_spritesheet_palette, medium_level, 1.0)
             self.darker_static_fader = PaletteFader(static_spritesheet_palette, darker_level, 1.0)


### PR DESCRIPTION
i was trying the simpletest and kept hitting this error:

```
code.py output:
Traceback (most recent call last):
  File "code.py", line 66, in <module>
  File "adafruit_displayio_flipclock/flip_digit.py", line 132, in __init__
TypeError: 'module' object isn't callable
Code done running.
```

updating the palettefader import to `from cedargrove_palettefader.palettefader import PaletteFader` fixed the issue in `flip_digit.py`